### PR TITLE
Add --jpgquality parameter.

### DIFF
--- a/docs/focus-stack.1
+++ b/docs/focus-stack.1
@@ -18,6 +18,12 @@ options are available:
 Set output filename. If file already exists, it will be overwritten.
 
 .TP
+\fB\-\-jpgquality=\fI\,95\/\fR
+Set the leve lof quality of the JGEP files (final and intermediates 
+if asked to be writen). The value can go from 0 to 100 with a default 
+at 95.
+
+.TP
 \fB\-\-reference=\fI\,index\/\fR
 Select image index (starting from 0) to use as alignment reference.
 Images in a stack will usually vary in scale and position.
@@ -114,6 +120,10 @@ Combine all images in current directory, and write output to
 Combine all images, giving detailed printout of steps and write output to
 .B stacked.jpg
 
+.nf
+.B focus-stack --jpgquality=100 IMG*.JPG
+.fi
+Generate a JPEG with the maximum level of quality (no compression).
 
 .SH GPU ACCELERATION
 This application uses OpenCV library and its OpenCL acceleration interface.

--- a/docs/focus-stack.html
+++ b/docs/focus-stack.html
@@ -41,6 +41,12 @@ Usually good results are obtained with the default settings, but following
   </dd>
 </dl>
 <dl class="Bl-tag">
+  <dt class="It-tag"><b>--jpgquality=</b><i>95</i></dt>
+  <dd class="It-tag">Set the leve lof quality of the JGEP files (final and intermediates if asked to be writen). The value can go from 0 to 100 with a default at 95.
+    <div style="height: 1.00em;">&#x00A0;</div>
+  </dd>
+</dl>
+<dl class="Bl-tag">
   <dt class="It-tag"><b>--reference=</b><i>index</i></dt>
   <dd class="It-tag">Select image index (starting from 0) to use as alignment
       reference. Images in a stack will usually vary in scale and position. All
@@ -160,7 +166,12 @@ Combine all images in current directory, and write output to <b>output.jpg</b>
 <b>focus-stack --verbose --output=stacked.jpg IMG*.JPG</b>
 </pre>
 Combine all images, giving detailed printout of steps and write output to
-  <b>stacked.jpg</b>
+<b>stacked.jpg</b>
+<div style="height: 1.00em;">&#x00A0;</div>
+<pre>
+<b>focus-stack --jpgquality=100 IMG*.JPG</b>
+</pre>
+Generate a JPEG with the maximum level of quality (no compression).
 <div style="height: 1.00em;">&#x00A0;</div>
 <div style="height: 1.00em;">&#x00A0;</div>
 <h1 class="Sh" title="Sh" id="GPU_ACCELERATION"><a class="selflink" href="#GPU_ACCELERATION">GPU

--- a/src/focusstack.cc
+++ b/src/focusstack.cc
@@ -16,6 +16,7 @@ using namespace focusstack;
 
 FocusStack::FocusStack():
   m_output("output.jpg"),
+  m_jpgquality(95),
   m_disable_opencl(false),
   m_save_steps(false),
   m_verbose(false),
@@ -133,7 +134,7 @@ bool FocusStack::run()
 
       if (m_save_steps)
       {
-        worker.add(std::make_shared<Task_SaveImg>("grayscale_" + grayscale->basename(), grayscale));
+        worker.add(std::make_shared<Task_SaveImg>("grayscale_" + grayscale->basename(), grayscale, m_jpgquality));
       }
 
       // Perform image alignment, using the neighbour image as initial guess or reference
@@ -184,7 +185,7 @@ bool FocusStack::run()
       if (m_save_steps)
       {
         // Task_Align adds "aligned_" prefix to the filename, so just use that name for saving also.
-        worker.add(std::make_shared<Task_SaveImg>(aligned->filename(), aligned));
+        worker.add(std::make_shared<Task_SaveImg>(aligned->filename(), aligned, m_jpgquality));
       }
 
       // Convert aligned image to grayscale again.
@@ -270,7 +271,7 @@ bool FocusStack::run()
 
     if (m_save_steps)
     {
-      worker.add(std::make_shared<Task_SaveImg>(merged_gray->filename(), merged_gray));
+      worker.add(std::make_shared<Task_SaveImg>(merged_gray->filename(), merged_gray, m_jpgquality));
     }
 
     // Reassign pixel values
@@ -278,7 +279,7 @@ bool FocusStack::run()
     worker.add(reassigned);
 
     // Save result image
-    worker.add(std::make_shared<Task_SaveImg>(m_output, reassigned, refcolor));
+    worker.add(std::make_shared<Task_SaveImg>(m_output, reassigned, m_jpgquality, refcolor));
 
   } // Close scope to avoid holding onto the shared_ptr's in local variables
 

--- a/src/focusstack.hh
+++ b/src/focusstack.hh
@@ -27,6 +27,7 @@ public:
   void set_verbose(bool verbose) { m_verbose = verbose; }
   void set_threads(int threads) { m_threads = threads; }
   void set_reference(int refidx) { m_reference = refidx; }
+  void set_jpgquality(int level) { m_jpgquality = level; }
   void set_consistency(int level) { m_consistency = level; }
   void set_denoise(float level) { m_denoise = level; }
   void set_align_flags(int flags) { m_align_flags = static_cast<align_flags_t>(flags); }
@@ -44,6 +45,7 @@ private:
   int m_threads;
   int m_reference;
   int m_consistency;
+  int m_jpgquality;
   float m_denoise;
 };
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -52,6 +52,7 @@ int main(int argc, const char *argv[])
     std::cerr << "Usage: " << argv[0] << " [options] file1.jpg file2.jpg ...\n";
     std::cerr << "Options:\n"
                  "  --output=output.jpg           Set output filename\n"
+                 "  --jpgquality=95               Set output (JPG) quality 0..100 (default 95)\n"
                  "  --reference=0                 Set index of image used as alignment reference (default middle one)\n"
                  "  --global-align                Align directly against reference (default with neighbour image)\n"
                  "  --full-resolution-align       Use full resolution images in alignment (default max 2048 px)\n"
@@ -71,6 +72,7 @@ int main(int argc, const char *argv[])
 
   stack.set_inputs(options.get_filenames());
   stack.set_output(options.get_arg("--output", "output.jpg"));
+  stack.set_jpgquality(std::stoi(options.get_arg("--jpgquality", "95")));
   stack.set_save_steps(options.has_flag("--save-steps"));
   stack.set_disable_opencl(options.has_flag("--no-opencl"));
   stack.set_verbose(options.has_flag("--verbose") || options.has_flag("-v"));

--- a/src/task_saveimg.cc
+++ b/src/task_saveimg.cc
@@ -1,14 +1,16 @@
 #include "task_saveimg.hh"
 #include <opencv2/core/core.hpp>
 #include <opencv2/imgcodecs.hpp>
+#include <opencv2/highgui/highgui.hpp>
 
 using namespace focusstack;
 
-Task_SaveImg::Task_SaveImg(std::string filename, std::shared_ptr<ImgTask> input, std::shared_ptr<Task_LoadImg> origsize)
+Task_SaveImg::Task_SaveImg(std::string filename, std::shared_ptr<ImgTask> input, int jpgquality, std::shared_ptr<Task_LoadImg> origsize)
 {
   m_filename = filename;
   m_name = "Save " + filename;
 
+  m_jpgquality = jpgquality;
   m_input = input;
   m_depends_on.push_back(input);
 
@@ -48,7 +50,11 @@ void Task_SaveImg::task()
     img = tmp;
   }
 
-  cv::imwrite(m_filename, img);
+  std::vector<int> compression_params;
+  compression_params.push_back(CV_IMWRITE_JPEG_QUALITY);
+  compression_params.push_back(m_jpgquality);
+
+  cv::imwrite(m_filename, img, compression_params);
   m_input.reset();
   m_origsize.reset();
 }

--- a/src/task_saveimg.hh
+++ b/src/task_saveimg.hh
@@ -9,7 +9,7 @@ namespace focusstack {
 class Task_SaveImg: public Task
 {
 public:
-  Task_SaveImg(std::string filename, std::shared_ptr<ImgTask> input, std::shared_ptr<Task_LoadImg> origsize = nullptr);
+  Task_SaveImg(std::string filename, std::shared_ptr<ImgTask> input, int jpgquality, std::shared_ptr<Task_LoadImg> origsize = nullptr);
 
 private:
   virtual void task();

--- a/src/worker.hh
+++ b/src/worker.hh
@@ -35,6 +35,7 @@ protected:
 
   bool m_verbose;
   std::string m_filename;
+  int m_jpgquality;
   std::string m_name;
   std::mutex m_mutex;
   std::vector<std::shared_ptr<Task> > m_depends_on; // List of tasks this task needs as inputs


### PR DESCRIPTION
Hi,

I propose this patch to be able to manage the level of quality of the final JPEG (and the intermediates if asked to be writen).
Default value: 95.

Why?
Sometime, I need to retouch the image produced by focus-stack and I wish to keep the best quality until the very final file.

`$ ./focus-stack/build/focus-stack _*.jpg
Saved to output.jpg                               
$ ./focus-stack/build/focus-stack --output=output100.jpg --jpgquality=100 _*.jpg
Saved to output100.jpg                            
$ jhead output*
File name    : output100.jpg
File size    : 9089639 bytes
File date    : 2020:08:08 13:08:07
Resolution   : 5196 x 3462
JPEG Quality : 100

File name    : output.jpg
File size    : 3046668 bytes
File date    : 2020:08:08 13:05:52
Resolution   : 5196 x 3462
JPEG Quality : 95

$ 
`

It stay a warning, but I don't really know how to correct it. Sorry, I'm not a dev, I hope I didn't did some mess :)

Regards, Fabrice.
Ps. With a lot of delay, many thank for the last update we discuss (issue 4 Out Of Memory issue).