### PR TITLE
--version 1.4 not 1.0

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -16,7 +16,7 @@ int main(int argc, const char *argv[])
 
   if (options.has_flag("--version"))
   {
-    std::cerr << "focus-stack 1.0, git version " GIT_VERSION ", built " __DATE__ " " __TIME__ "\n"
+    std::cerr << "focus-stack 1.4, git version " GIT_VERSION ", built " __DATE__ " " __TIME__ "\n"
                  "Compiled with OpenCV version " CV_VERSION "\n"
                  "Copyright (c) 2019 Petteri Aimonen\n\n"
 


### PR DESCRIPTION
Hi,
was surprised when entering --version that it was displayed version 1.0 and not 1.4. And that's why I "make/make install" the library twice.
You can either pull or make the small change yourself. Maybe there is also an automatic way to update the version.