### PR TITLE
made install command mac-compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ clean:
 	mkdir -p build
 
 install: all
-	install -D build/focus-stack "$(DESTDIR)$(prefix)/bin/focus-stack"
+	mkdir -p "$(DESTDIR)$(prefix)/bin/"
+	install build/focus-stack "$(DESTDIR)$(prefix)/bin/focus-stack"
 	mkdir -p "$(DESTDIR)$(prefix)/share/man/man1/"
 	gzip -c docs/focus-stack.1 > "$(DESTDIR)$(prefix)/share/man/man1/focus-stack.1.gz"
 


### PR DESCRIPTION
When running `make install` on MacOS I was get the following output:
```
% make install
which ronn && make update_docs || true
install -D build/focus-stack "/usr/local/bin/focus-stack"
usage: install [-bCcpSsUv] [-f flags] [-g group] [-m mode] [-o owner]
               [-M log] [-D dest] [-h hash] [-T tags]
               [-B suffix] [-l linkflags] [-N dbdir]
               file1 file2
       install [-bCcpSsUv] [-f flags] [-g group] [-m mode] [-o owner]
               [-M log] [-D dest] [-h hash] [-T tags]
               [-B suffix] [-l linkflags] [-N dbdir]
               file1 ... fileN directory
       install -dU [-vU] [-g group] [-m mode] [-N dbdir] [-o owner]
               [-M log] [-D dest] [-h hash] [-T tags]
               directory ...
make: *** [install] Error 64
```

`man install` (on MacOS) says:
```
     -D destdir
             Specify the DESTDIR (top of the file hierarchy) that the items are installed in to.  If -M
             metalog is in use, a leading string of “destdir” will be removed from the file names logged
             to the metalog.  This option does not affect where the actual files are installed.
```

which is different than the functionality on linux:
```
-D
    create all leading components of DEST except the last, or all components of --target-directory, then copy SOURCE to DEST
```

To avoid this incompatibility I just replaced the `-D` with a `mkdir -p` to emulate the same behavior. 

After this change, running `make install` works properly; `focus-stack` is on my path and `man focus-stack` shows the proper man page.