### PR TITLE
Fix GitHub workflow issues in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,13 +36,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: focus-stack/DEBUILD/*.deb
-          name: Focus-stack Ubuntu 20.04 package
-      
+          name: Focus-stack Ubuntu 22.04 package
+
       - name: Upload ddeb
         uses: actions/upload-artifact@v4
         with:
           path: focus-stack/DEBUILD/*.ddeb
-          name: Focus-stack Ubuntu 20.04 debug symbols
+          name: Focus-stack Ubuntu 22.04 debug symbols
 
       - name: Upload appimage
         uses: actions/upload-artifact@v4
@@ -138,24 +138,39 @@ jobs:
 
   release:
     needs: [linux_binary, mac_binary, windows_binary]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v4
         with:
           path: focus-stack
           fetch-depth: "0"
-      
-      - name: Download artifacts
-        run: |
-          mkdir -p focus-stack/distrib
-          cd focus-stack/distrib
-          gh run --repo ${GITHUB_REPOSITORY} download -n 'Focus-stack Mac OS X application'
-          gh run --repo ${GITHUB_REPOSITORY} download -n 'Focus-stack Ubuntu 20.04 package'
-          gh run --repo ${GITHUB_REPOSITORY} download -n 'Focus-stack Linux x86_64 AppImage'
-          gh run --repo ${GITHUB_REPOSITORY} download -n 'Focus-stack Windows binary'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download Mac OS X artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: Focus-stack Mac OS X application
+          path: focus-stack/distrib
+
+      - name: Download Ubuntu package artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: Focus-stack Ubuntu 22.04 package
+          path: focus-stack/distrib
+
+      - name: Download AppImage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: Focus-stack Linux x86_64 AppImage
+          path: focus-stack/distrib
+
+      - name: Download Windows binary artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: Focus-stack Windows binary
+          path: focus-stack/distrib
       
       - name: List artifacts
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,34 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: focus-stack/distrib/focus-stack_MacOSX.zip
-          name: Focus-stack Mac OS X application
+          name: Focus-stack Mac OS X 14 application
+
+  mac_binary_26:
+    name: Build binary on Mac OS X 26
+    runs-on: macos-26
+
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v4
+        with:
+          path: focus-stack
+          fetch-depth: "0"
+
+      - name: Install build dependencies
+        run: |
+          brew install opencv pkg-config dylibbundler
+
+      - name: Build binary
+        run: |
+          cd focus-stack
+          make
+          sudo make distrib/focus-stack_MacOSX.zip
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          path: focus-stack/distrib/focus-stack_MacOSX.zip
+          name: Focus-stack Mac OS X 26 application
 
   windows_binary:
     name: Build binary on Windows 2022
@@ -137,7 +164,7 @@ jobs:
           name: Focus-stack Windows debug symbols
 
   release:
-    needs: [linux_binary, mac_binary, windows_binary]
+    needs: [linux_binary, mac_binary, mac_binary_26, windows_binary]
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -148,10 +175,16 @@ jobs:
           path: focus-stack
           fetch-depth: "0"
 
-      - name: Download Mac OS X artifact
+      - name: Download Mac OS X 14 artifact
         uses: actions/download-artifact@v4
         with:
-          name: Focus-stack Mac OS X application
+          name: Focus-stack Mac OS X 14 application
+          path: focus-stack/distrib
+
+      - name: Download Mac OS X 26 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: Focus-stack Mac OS X 26 application
           path: focus-stack/distrib
 
       - name: Download Ubuntu package artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,6 +168,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: write
+      actions: read
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v4


### PR DESCRIPTION
- Update artifact names from Ubuntu 20.04 to 22.04 to match actual runner version
- Fix release job to use ubuntu-22.04 instead of ubuntu-20.04 for consistency
- Replace incorrect gh run download commands with proper actions/download-artifact@v4
- Add explicit contents: write permission to release job for GitHub CLI operations

These changes ensure the workflow uses consistent Ubuntu versions across all jobs and follows GitHub Actions best practices for artifact handling.