### PR TITLE
Add `--no-transform` and `--no-align`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 *.o
+*.obj
+*.pdb
 *.kdev4
 build
+gitrev
 Makefile.local
+.vs/

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ For advanced usage, see `--help` for list of all options or [check the manual](d
       --no-transform                Don't attempt to correct image position alignment
       --align-only                  Only align the input image stack and exit
       --align-keep-size             Keep original image size by not cropping alignment borders
+      --no-align                    Skips the alignment completely, overrides all other alignment options
 
     Image merge options:
       --consistency=2               Neighbour pixel consistency filter level 0..2 (default 2)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ For advanced usage, see `--help` for list of all options or [check the manual](d
       --full-resolution-align       Use full resolution images in alignment (default max 2048 px)
       --no-whitebalance             Don't attempt to correct white balance differences
       --no-contrast                 Don't attempt to correct contrast and exposure differences
+      --no-transform                Don't attempt to correct image position alignment
       --align-only                  Only align the input image stack and exit
       --align-keep-size             Keep original image size by not cropping alignment borders
 

--- a/docs/focus-stack.html
+++ b/docs/focus-stack.html
@@ -167,6 +167,9 @@ of the aligned images with external tools.</dd>
 <dt><code>--align-keep-size</code></dt>
 <dd>Keep original image size by not cropping alignment borders. The
 wavelet processing borders still get cropped, unlike with --nocrop.</dd>
+<dt><code>--no-align</code></dt>
+<dd>Skips the alignment step completely. This will override all other
+alignment options.</dd>
 </dl>
 
 

--- a/docs/focus-stack.html
+++ b/docs/focus-stack.html
@@ -156,6 +156,11 @@ white balance adjustment.</dd>
 <dt><code>--no-contrast</code></dt>
 <dd>If camera exposure is manually controlled, this option can be used
 to skip unnecessary exposure compensation.</dd>
+<dt><code>--no-transform</code></dt>
+<dd>The application tries to resize and rotate the images in a stack to
+align the content of the images. If you already have aligned images
+or the content isn't static and confuses the algorithm, this option
+can be specified to skip the transformation.</dd>
 <dt><code>--align-only</code></dt>
 <dd>Only align the image stack and exit. Useful for further processing
 of the aligned images with external tools.</dd>

--- a/docs/focus-stack.md
+++ b/docs/focus-stack.md
@@ -98,6 +98,10 @@ following options are available:
     Keep original image size by not cropping alignment borders. The
     wavelet processing borders still get cropped, unlike with --nocrop.
 
+  * `--no-align`:
+    Skips the alignment step completely. This will override all other
+    alignment options.
+
 ### Image merge options
 
 * `--consistency`=level:

--- a/docs/focus-stack.md
+++ b/docs/focus-stack.md
@@ -84,6 +84,12 @@ following options are available:
     If camera exposure is manually controlled, this option can be used
     to skip unnecessary exposure compensation.
 
+  * `--no-transform`:
+    The application tries to resize and rotate the images in a stack to
+    align the content of the images. If you already have aligned images
+    or the content isn't static and confuses the algorithm, this option
+    can be specified to skip the transformation.
+
   * `--align-only`:
     Only align the image stack and exit. Useful for further processing
     of the aligned images with external tools.

--- a/src/focusstack.hh
+++ b/src/focusstack.hh
@@ -35,6 +35,7 @@ public:
     ALIGN_GLOBAL              = 0x08,
     ALIGN_KEEP_SIZE           = 0x10,
     ALIGN_NO_TRANSFORM        = 0x20,
+    ALIGN_NONE                = 0x40
   };
 
   enum log_level_t

--- a/src/focusstack.hh
+++ b/src/focusstack.hh
@@ -34,6 +34,7 @@ public:
     ALIGN_FULL_RESOLUTION     = 0x04,
     ALIGN_GLOBAL              = 0x08,
     ALIGN_KEEP_SIZE           = 0x10,
+    ALIGN_NO_TRANSFORM        = 0x20,
   };
 
   enum log_level_t

--- a/src/main.cc
+++ b/src/main.cc
@@ -68,6 +68,7 @@ int main(int argc, const char *argv[])
                  "  --no-transform                Don't attempt to correct image position alignment\n"
                  "  --align-only                  Only align the input image stack and exit\n"
                  "  --align-keep-size             Keep original image size by not cropping alignment borders\n";
+                 "  --no-align                    Skips the alignment completely, overrides all other alignment options\n";
     std::cerr << "\n";
     std::cerr << "Image merge options:\n"
                  "  --consistency=2               Neighbour pixel consistency filter level 0..2 (default 2)\n"
@@ -111,6 +112,7 @@ int main(int argc, const char *argv[])
   if (options.has_flag("--no-contrast"))              flags |= FocusStack::ALIGN_NO_CONTRAST;
   if (options.has_flag("--no-transform"))             flags |= FocusStack::ALIGN_NO_TRANSFORM;
   if (options.has_flag("--align-keep-size"))          flags |= FocusStack::ALIGN_KEEP_SIZE;
+  if (options.has_flag("--no-align"))                 flags  = FocusStack::ALIGN_NONE;
   stack.set_align_flags(flags);
 
   if (options.has_flag("--reference"))
@@ -118,7 +120,7 @@ int main(int argc, const char *argv[])
     stack.set_reference(std::stoi(options.get_arg("--reference")));
   }
 
-  if (options.has_flag("--align-only"))
+  if (options.has_flag("--align-only") && !options.has_flag("--no-align"))
   {
     stack.set_align_only(true);
     stack.set_output(options.get_arg("--output", "aligned_"));

--- a/src/main.cc
+++ b/src/main.cc
@@ -65,6 +65,7 @@ int main(int argc, const char *argv[])
                  "  --full-resolution-align       Use full resolution images in alignment (default max 2048 px)\n"
                  "  --no-whitebalance             Don't attempt to correct white balance differences\n"
                  "  --no-contrast                 Don't attempt to correct contrast and exposure differences\n"
+                 "  --no-transform                Don't attempt to correct image position alignment\n"
                  "  --align-only                  Only align the input image stack and exit\n"
                  "  --align-keep-size             Keep original image size by not cropping alignment borders\n";
     std::cerr << "\n";
@@ -108,6 +109,7 @@ int main(int argc, const char *argv[])
   if (options.has_flag("--full-resolution-align"))    flags |= FocusStack::ALIGN_FULL_RESOLUTION;
   if (options.has_flag("--no-whitebalance"))          flags |= FocusStack::ALIGN_NO_WHITEBALANCE;
   if (options.has_flag("--no-contrast"))              flags |= FocusStack::ALIGN_NO_CONTRAST;
+  if (options.has_flag("--no-transform"))             flags |= FocusStack::ALIGN_NO_TRANSFORM;
   if (options.has_flag("--align-keep-size"))          flags |= FocusStack::ALIGN_KEEP_SIZE;
   stack.set_align_flags(flags);
 

--- a/src/task_align.cc
+++ b/src/task_align.cc
@@ -58,7 +58,7 @@ Task_Align::Task_Align(std::shared_ptr<ImgTask> refgray, std::shared_ptr<ImgTask
 
 void Task_Align::task()
 {
-  if (m_refcolor == m_srccolor)
+  if (m_refcolor == m_srccolor || m_flags == FocusStack::ALIGN_NONE)
   {
     m_result = m_srccolor->img();
   }

--- a/src/task_align.cc
+++ b/src/task_align.cc
@@ -73,7 +73,10 @@ void Task_Align::task()
     m_roi = m_srcgray->valid_area();
 
     // Perform low resolution initial geometric alignment
-    match_transform(256, true);
+    if (!(m_flags & FocusStack::ALIGN_NO_TRANSFORM))
+    {
+      match_transform( 256, true );
+    }
 
     // Perform grayscale brightness alignment
     if (!(m_flags & FocusStack::ALIGN_NO_CONTRAST))
@@ -81,23 +84,26 @@ void Task_Align::task()
       match_contrast();
     }
 
-    // Perform color/whit balance alignment
+    // Perform color/white balance alignment
     if (!(m_flags & FocusStack::ALIGN_NO_WHITEBALANCE) && m_srccolor->img().channels() == 3)
     {
       match_whitebalance();
     }
 
     // Finally, do the high resolution geometric alignment step
-    if (m_flags & FocusStack::ALIGN_FULL_RESOLUTION)
+    if (!(m_flags & FocusStack::ALIGN_NO_TRANSFORM))
     {
-      int res = std::max(m_srccolor->img().cols, m_srccolor->img().rows);
-      match_transform(res, false);
-    }
-    else
-    {
-      // By default limit image resolution used in alignment to 2k.
-      // Because this uses subpixel positioning, higher resolution provides little benefit.
-      match_transform(2048, false);
+      if (m_flags & FocusStack::ALIGN_FULL_RESOLUTION)
+      {
+        int res = std::max(m_srccolor->img().cols, m_srccolor->img().rows);
+        match_transform(res, false);
+      }
+      else
+      {
+        // By default limit image resolution used in alignment to 2k.
+        // Because this uses subpixel positioning, higher resolution provides little benefit.
+        match_transform(2048, false);
+      }
     }
 
     // The image is now aligned against the neighbour image.


### PR DESCRIPTION
This PR adds two new command line options:

- `--no-transform`
  - skips the image transform (scale, rotation)
  - implemented as described in #11
- `--no-align`
  - skips the whole alignment step
  - overrides all other alignment options
  - as requested in #28 and https://github.com/PetteriAimonen/focus-stack/issues/58#issuecomment-3697275388